### PR TITLE
Add message title for Google Cloud Messge (GCM)

### DIFF
--- a/src/Services/AbstractPushService.php
+++ b/src/Services/AbstractPushService.php
@@ -10,6 +10,12 @@ abstract class AbstractPushService implements PushService
     protected $messageText = null;
 
     /**
+     * @var string|null
+     *   The text of the message
+     */
+    protected $messageTitle = null;
+
+    /**
      * @var array|null
      *   The data of the message
      */

--- a/src/Services/ApplePushService.php
+++ b/src/Services/ApplePushService.php
@@ -13,6 +13,11 @@ class ApplePushService extends AbstractPushService
      */
     private $client;
 
+    public function setMessageTitle($title)
+    {
+        throw new RuntimeException('APNS does not support message title');
+    }
+
     /**
      * @inheritdoc
      */

--- a/src/Services/GooglePushService.php
+++ b/src/Services/GooglePushService.php
@@ -14,12 +14,6 @@ class GooglePushService extends AbstractPushService
     private $client;
 
     /**
-     * @var string
-     *   The title of message
-     */
-    protected $messageTitle = null;
-
-    /**
      * @inheritdoc
      */
     public function loadConfiguration($config)

--- a/src/Services/GooglePushService.php
+++ b/src/Services/GooglePushService.php
@@ -14,6 +14,12 @@ class GooglePushService extends AbstractPushService
     private $client;
 
     /**
+     * @var string
+     *   The title of message
+     */
+    protected $messageTitle = null;
+
+    /**
      * @inheritdoc
      */
     public function loadConfiguration($config)
@@ -36,6 +42,17 @@ class GooglePushService extends AbstractPushService
     }
 
     /**
+     * Set message title
+     *
+     * @param string $title message title
+     */
+    public function setMessageTitle($title)
+    {
+        $this->messageTitle = $title;
+        return $this;
+    }
+
+    /**
      * @inheritdoc
      */
     public function send()
@@ -46,6 +63,10 @@ class GooglePushService extends AbstractPushService
 
         if ($this->messageData !== null) {
             $body['data'] = $this->messageData;
+        }
+
+        if ($this->messageTitle !== null) {
+            $body['data']['title'] = $this->messageTitle;
         }
 
         if ($this->messageText !== null) {

--- a/src/Services/GooglePushService.php
+++ b/src/Services/GooglePushService.php
@@ -49,7 +49,7 @@ class GooglePushService extends AbstractPushService
         }
 
         if ($this->messageText !== null) {
-            $body['data']['message'] = $this->messageText;
+            $body['data']['content'] = $this->messageText;
         }
 
         $ok = [];

--- a/src/Services/PushService.php
+++ b/src/Services/PushService.php
@@ -24,6 +24,16 @@ interface PushService
     public function setMessageText($message);
 
     /**
+     * Set the message title for this push message.
+     *
+     * @param string $title
+     *   The message title to set
+     * @return self
+     *   This instance, to allow chaining
+     */
+    public function setMessageTitle($title);
+
+    /**
      * Set the message data for this push message.
      * This will clear any previous message data
      *


### PR DESCRIPTION
iOS app does not support message title, but Android can.

I add message title in `GooglePushService.php` and change work flow in method `send()` to set title for Android message.

I've test on Sony mobile. May need some help testing on other devices.
Thanks
